### PR TITLE
Update dionea package name on setup.bash

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -29,7 +29,7 @@ sudo apt-get install -y python-software-properties
 #add dionaea repo
 sudo add-apt-repository -y ppa:honeynet/nightly
 sudo apt-get update
-sudo apt-get install -y dionaea
+sudo apt-get install -y dionaea-phibo
 
 #make directories
 sudo mkdir -p /var/dionaea/wwwroot


### PR DESCRIPTION
When i first executed the setup.bash on a vainilla install of Ubuntu 11.04, on the step of
sudo apt-get install -y dionaea

I got an error where there were no candidates available with that name

Package dionaea is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'dionaea' has no installation candidate

Now on the same ppa repository the package is called dionaea-phibo, changing the name will install and configure the honeypot correclty.

Thanks for the scripts and configurations for setting up this honeypot setup.
